### PR TITLE
Change the log severity leve from ERROR to NOTICE if getStatus is not supported by vendor

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -706,9 +706,14 @@ sai_status_t Syncd::processGetStatsEvent(
 
     std::vector<swss::FieldValueTuple> entry;
 
-    if (status != SAI_STATUS_SUCCESS)
+    if (SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status)
+            || status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
     {
-        SWSS_LOG_ERROR("Failed to get stats");
+        SWSS_LOG_NOTICE("Getting stats on %s is not supported on the platform", key.c_str());
+    }
+    else if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Error occurred when getting stats on %s", key.c_str());
     }
     else
     {


### PR DESCRIPTION
Change the log severity level from ERROR to NOTICE if getStatus is not supported by vendor

Signed-off-by: Stephen Sun <stephens@nvidia.com>