### PR TITLE
Change the log severity level from ERROR to NOTICE if getStatus is not supported by vendor (cherry-pick #908)

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -705,7 +705,7 @@ sai_status_t Syncd::processGetStatsEvent(
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to get stats");
+        SWSS_LOG_NOTICE("Getting stats error: %s", sai_serialize_status(status).c_str());
     }
     else
     {


### PR DESCRIPTION
Change the log severity level from ERROR to NOTICE if getStatus is not supported by vendor
This is to cherry-pick 908 to 202106.

Signed-off-by: Stephen Sun stephens@nvidia.com