### PR TITLE
Change the log severity leve from ERROR to NOTICE if getStatus is not supported by vendor

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -702,7 +702,7 @@ sai_status_t Syncd::processGetStatsEvent(
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to get stats");
+        SWSS_LOG_NOTICE("Getting stats error: %s", sai_serialize_status(status).c_str());
     }
     else
     {


### PR DESCRIPTION
This is to cherry-pick PR 908 to 202012