### PR TITLE
ASIC/SDK health event

### DIFF
--- a/lib/Switch.cpp
+++ b/lib/Switch.cpp
@@ -83,6 +83,11 @@ void Switch::updateNotifications(
                     (sai_switch_state_change_notification_fn)attr.value.ptr;
                 break;
 
+            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+                m_switchNotifications.on_switch_asic_sdk_health_event =
+                    (sai_switch_asic_sdk_health_event_notification_fn)attr.value.ptr;
+                break;
+
             case SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY:
                 m_switchNotifications.on_switch_shutdown_request =
                     (sai_switch_shutdown_request_notification_fn)attr.value.ptr;

--- a/meta/Makefile.am
+++ b/meta/Makefile.am
@@ -32,6 +32,7 @@ libsaimeta_la_SOURCES = \
 				NotificationNatEvent.cpp \
 				NotificationPortStateChange.cpp \
 				NotificationQueuePfcDeadlock.cpp \
+				NotificationSwitchAsicSdkHealthEvent.cpp \
 				NotificationSwitchShutdownRequest.cpp \
 				NotificationSwitchStateChange.cpp \
 				NotificationBfdSessionStateChange.cpp \

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -6513,6 +6513,54 @@ void Meta::meta_sai_on_switch_state_change(
     // we should not snoop switch_id, since switch id should be created directly by user
 }
 
+void Meta::meta_sai_on_switch_asic_sdk_health_event(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    if (!sai_metadata_get_enum_value_name(
+            &sai_metadata_enum_sai_switch_asic_sdk_health_severity_t,
+            severity))
+    {
+        SWSS_LOG_WARN("Switch ASIC/SDK health event severity value (%d) not found in sai_switch_asic_sdk_health_severity_t",
+                      severity);
+    }
+
+    if (!sai_metadata_get_enum_value_name(
+            &sai_metadata_enum_sai_switch_asic_sdk_health_category_t,
+            category))
+    {
+        SWSS_LOG_WARN("Switch ASIC/SDK health event category value (%d) not found in sai_switch_asic_sdk_health_severity_t",
+                      category);
+    }
+
+    auto ot = objectTypeQuery(switch_id);
+
+    if (ot != SAI_OBJECT_TYPE_SWITCH)
+    {
+        SWSS_LOG_WARN("switch_id %s is of type %s, but expected SAI_OBJECT_TYPE_SWITCH",
+                sai_serialize_object_id(switch_id).c_str(),
+                sai_serialize_object_type(ot).c_str());
+
+        return;
+    }
+
+    sai_object_meta_key_t switch_meta_key = { .objecttype = ot , .objectkey = { .key = { .object_id = switch_id } } };
+
+    if (!m_saiObjectCollection.objectExists(switch_meta_key))
+    {
+        SWSS_LOG_ERROR("switch_id %s don't exists in local database",
+                sai_serialize_object_id(switch_id).c_str());
+    }
+
+    // we should not snoop switch_id, since switch id should be created directly by user
+}
+
 void Meta::meta_sai_on_switch_shutdown_request(
         _In_ sai_object_id_t switch_id)
 {

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -205,6 +205,14 @@ namespace saimeta
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_switch_oper_status_t switch_oper_status);
 
+            void meta_sai_on_switch_asic_sdk_health_event(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_switch_asic_sdk_health_severity_t severity,
+                    _In_ sai_timespec_t timestamp,
+                    _In_ sai_switch_asic_sdk_health_category_t category,
+                    _In_ sai_switch_health_data_t data,
+                    _In_ const sai_u8_list_t description);
+
             void meta_sai_on_switch_shutdown_request(
                     _In_ sai_object_id_t switch_id);
 

--- a/meta/NotificationFactory.cpp
+++ b/meta/NotificationFactory.cpp
@@ -5,6 +5,7 @@
 #include "NotificationQueuePfcDeadlock.h"
 #include "NotificationSwitchShutdownRequest.h"
 #include "NotificationSwitchStateChange.h"
+#include "NotificationSwitchAsicSdkHealthEvent.h"
 #include "NotificationBfdSessionStateChange.h"
 #include "NotificationTwampSessionEvent.h"
 #include "NotificationPortHostTxReadyEvent.h"
@@ -37,6 +38,9 @@ std::shared_ptr<Notification> NotificationFactory::deserialize(
 
     if (name == SAI_SWITCH_NOTIFICATION_NAME_SWITCH_SHUTDOWN_REQUEST)
         return std::make_shared<NotificationSwitchShutdownRequest>(serializedNotification);
+
+    if (name == SAI_SWITCH_NOTIFICATION_NAME_SWITCH_ASIC_SDK_HEALTH_EVENT)
+        return std::make_shared<NotificationSwitchAsicSdkHealthEvent>(serializedNotification);
 
     if (name == SAI_SWITCH_NOTIFICATION_NAME_SWITCH_STATE_CHANGE)
         return std::make_shared<NotificationSwitchStateChange>(serializedNotification);

--- a/meta/NotificationSwitchAsicSdkHealthEvent.cpp
+++ b/meta/NotificationSwitchAsicSdkHealthEvent.cpp
@@ -1,0 +1,74 @@
+#include "NotificationSwitchAsicSdkHealthEvent.h"
+
+#include "swss/logger.h"
+
+#include "sai_serialize.h"
+
+using namespace sairedis;
+
+NotificationSwitchAsicSdkHealthEvent::NotificationSwitchAsicSdkHealthEvent(
+        _In_ const std::string& serializedNotification):
+    Notification(
+            SAI_SWITCH_NOTIFICATION_TYPE_SWITCH_ASIC_SDK_HEALTH_EVENT,
+            serializedNotification)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_switch_asic_sdk_health_event(serializedNotification,
+                                                 m_switchId,
+                                                 m_severity,
+                                                 m_timestamp,
+                                                 m_category,
+                                                 m_healthData,
+                                                 m_description);
+}
+
+NotificationSwitchAsicSdkHealthEvent::~NotificationSwitchAsicSdkHealthEvent()
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_free_switch_asic_sdk_health_event(m_description);
+}
+
+sai_object_id_t NotificationSwitchAsicSdkHealthEvent::getSwitchId() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_switchId;
+}
+
+sai_object_id_t NotificationSwitchAsicSdkHealthEvent::getAnyObjectId() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_switchId;
+}
+
+void NotificationSwitchAsicSdkHealthEvent::processMetadata(
+        _In_ std::shared_ptr<saimeta::Meta> meta) const
+{
+    SWSS_LOG_ENTER();
+
+    meta->meta_sai_on_switch_asic_sdk_health_event(m_switchId,
+                                                   m_severity,
+                                                   m_timestamp,
+                                                   m_category,
+                                                   m_healthData,
+                                                   m_description);
+}
+
+void NotificationSwitchAsicSdkHealthEvent::executeCallback(
+        _In_ const sai_switch_notifications_t& switchNotifications) const
+{
+    SWSS_LOG_ENTER();
+
+    if (switchNotifications.on_switch_asic_sdk_health_event)
+    {
+        switchNotifications.on_switch_asic_sdk_health_event(m_switchId,
+                                                            m_severity,
+                                                            m_timestamp,
+                                                            m_category,
+                                                            m_healthData,
+                                                            m_description);
+    }
+}

--- a/meta/NotificationSwitchAsicSdkHealthEvent.h
+++ b/meta/NotificationSwitchAsicSdkHealthEvent.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Notification.h"
+
+namespace sairedis
+{
+    class NotificationSwitchAsicSdkHealthEvent:
+        public Notification
+    {
+        public:
+
+            NotificationSwitchAsicSdkHealthEvent(
+                    _In_ const std::string& serializedNotification);
+
+            virtual ~NotificationSwitchAsicSdkHealthEvent();
+
+        public:
+
+            virtual sai_object_id_t getSwitchId() const override;
+
+            virtual sai_object_id_t getAnyObjectId() const override;
+
+            virtual void processMetadata(
+                    _In_ std::shared_ptr<saimeta::Meta> meta) const override;
+
+            virtual void executeCallback(
+                    _In_ const sai_switch_notifications_t& switchNotifications) const override;
+
+        private:
+
+            sai_object_id_t m_switchId;
+            sai_switch_asic_sdk_health_severity_t m_severity;
+            sai_switch_asic_sdk_health_category_t m_category;
+            sai_timespec_t m_timestamp;
+            sai_switch_health_data_t m_healthData;
+            sai_u8_list_t m_description;
+    };
+}

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -1131,6 +1131,41 @@ std::string sai_serialize_egress_drop_reason(
     return sai_serialize_enum(reason, &sai_metadata_enum_sai_out_drop_reason_t);
 }
 
+std::string sai_serialize_timespec(
+        _In_ const sai_timespec_t &timespec)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["tv_sec"] = sai_serialize_number<uint64_t>(timespec.tv_sec);
+    j["tv_nsec"] = sai_serialize_number<uint32_t>(timespec.tv_nsec);
+
+    return j.dump();
+}
+
+std::string sai_serialize_switch_asic_sdk_health_event(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ const sai_timespec_t &timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ const sai_switch_health_data_t &data,
+        _In_ const sai_u8_list_t &description)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+
+    j["switch_id"] = sai_serialize_object_id(switch_id);
+    j["severity"] = sai_serialize_enum(severity, &sai_metadata_enum_sai_switch_asic_sdk_health_severity_t);
+    j["timestamp"] = sai_serialize_timespec(timestamp);
+    j["category"] = sai_serialize_enum(category, &sai_metadata_enum_sai_switch_asic_sdk_health_category_t);
+    j["data.data_type"] = sai_serialize_enum(data.data_type, &sai_metadata_enum_sai_health_data_type_t);
+    j["description"] = sai_serialize_number_list(description, false);
+
+    return j.dump();
+}
+
 std::string sai_serialize_switch_shutdown_request(
         _In_ sai_object_id_t switch_id)
 {
@@ -1299,7 +1334,7 @@ template <typename T>
 std::string sai_serialize_number_list(
         _In_ const T& list,
         _In_ bool countOnly,
-        _In_ bool hex = false)
+        _In_ bool hex)
 {
     SWSS_LOG_ENTER();
 
@@ -4145,6 +4180,63 @@ void sai_deserialize_switch_oper_status(
 
     sai_deserialize_object_id(j["switch_id"], switch_id);
     sai_deserialize_enum(j["status"], &sai_metadata_enum_sai_switch_oper_status_t, (int32_t&)status);
+}
+
+void sai_deserialize_timespec(
+        _In_ const std::string& s,
+        _Out_ sai_timespec_t &timestamp)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+    try
+    {
+        j = json::parse(s);
+    }
+    catch (const std::exception&)
+    {
+        SWSS_LOG_ERROR("Received an exception after trying to parse timespec_t from %s", s.c_str());
+    }
+
+    sai_deserialize_number<uint64_t>(j["tv_sec"], timestamp.tv_sec);
+    sai_deserialize_number<uint32_t>(j["tv_nsec"], timestamp.tv_nsec);
+}
+
+void sai_deserialize_switch_asic_sdk_health_event(
+        _In_ const std::string& s,
+        _Out_ sai_object_id_t &switch_id,
+        _Out_ sai_switch_asic_sdk_health_severity_t &severity,
+        _Out_ sai_timespec_t &timestamp,
+        _Out_ sai_switch_asic_sdk_health_category_t &category,
+        _Out_ sai_switch_health_data_t &data,
+        _Out_ sai_u8_list_t &description)
+{
+    SWSS_LOG_ENTER();
+
+    json j;
+    try
+    {
+        j = json::parse(s);
+    }
+    catch (const std::exception&)
+    {
+        SWSS_LOG_ERROR("Received an exception after trying to parse switch_asic_sdk_health_event from %s", s.c_str());
+    }
+
+    sai_deserialize_object_id(j["switch_id"], switch_id);
+    sai_deserialize_enum(j["severity"], &sai_metadata_enum_sai_switch_asic_sdk_health_severity_t, (int32_t&)severity);
+    sai_deserialize_timespec(j["timestamp"], timestamp);
+    sai_deserialize_enum(j["category"], &sai_metadata_enum_sai_switch_asic_sdk_health_category_t, (int32_t&)category);
+    int32_t data_type;
+    sai_deserialize_enum(j["data.data_type"], &sai_metadata_enum_sai_health_data_type_t, data_type);
+    data.data_type = (sai_health_data_type_t)data_type;
+    data.data_type = SAI_HEALTH_DATA_TYPE_GENERAL;
+    sai_deserialize_number_list(j["description"], description, false, false);
+}
+
+void sai_deserialize_free_switch_asic_sdk_health_event(_In_ sai_u8_list_t &description)
+{
+    sai_free_list(description);
 }
 
 void sai_deserialize_switch_shutdown_request(

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -204,6 +204,17 @@ std::string sai_serialize_switch_oper_status(
         _In_ sai_object_id_t switch_id,
         _In_ sai_switch_oper_status_t status);
 
+std::string sai_serialize_timespec(
+        _In_ const sai_timespec_t &timespec);
+
+std::string sai_serialize_switch_asic_sdk_health_event(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ const sai_timespec_t &timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ const sai_switch_health_data_t &data,
+        _In_ const sai_u8_list_t &description);
+
 std::string sai_serialize_switch_shutdown_request(
         _In_ sai_object_id_t switch_id);
 
@@ -218,6 +229,12 @@ std::string sai_serialize_enum_list(
 
 std::string sai_serialize_number(
         _In_ uint32_t number,
+        _In_ bool hex = false);
+
+template <typename T>
+std::string sai_serialize_number_list(
+        _In_ const T& list,
+        _In_ bool countOnly,
         _In_ bool hex = false);
 
 std::string sai_serialize_attr_id(
@@ -326,6 +343,19 @@ void sai_deserialize_switch_oper_status(
         _In_ const std::string& s,
         _Out_ sai_object_id_t &switch_id,
         _Out_ sai_switch_oper_status_t& status);
+
+void sai_deserialize_timespec(
+        _In_ const std::string& s,
+        _Out_ sai_timespec_t &timestamp);
+
+void sai_deserialize_switch_asic_sdk_health_event(
+        _In_ const std::string& s,
+        _Out_ sai_object_id_t &switch_id,
+        _Out_ sai_switch_asic_sdk_health_severity_t &severity,
+        _Out_ sai_timespec_t &timestamp,
+        _Out_ sai_switch_asic_sdk_health_category_t &category,
+        _Out_ sai_switch_health_data_t &data,
+        _Out_ sai_u8_list_t &description);
 
 void sai_deserialize_switch_shutdown_request(
         _In_ const std::string& s,
@@ -535,6 +565,9 @@ void sai_deserialize_free_queue_deadlock_ntf(
 void sai_deserialize_free_bfd_session_state_ntf(
         _In_ uint32_t count,
         _In_ sai_bfd_session_state_notification_t* bfdsessionstate);
+
+void sai_deserialize_free_switch_asic_sdk_health_event(
+        _In_ sai_u8_list_t &description);
 
 void sai_deserialize_ingress_priority_group_attr(
         _In_ const std::string& s,

--- a/saiplayer/SaiPlayer.cpp
+++ b/saiplayer/SaiPlayer.cpp
@@ -87,6 +87,7 @@ SaiPlayer::SaiPlayer(
     m_sn.onFdbEvent = std::bind(&SaiPlayer::onFdbEvent, this, _1, _2);
     m_sn.onPortStateChange = std::bind(&SaiPlayer::onPortStateChange, this, _1, _2);
     m_sn.onQueuePfcDeadlock = std::bind(&SaiPlayer::onQueuePfcDeadlock, this, _1, _2);
+    m_sn.onSwitchAsicSdkHealthEvent = std::bind(&SaiPlayer::onSwitchAsicSdkHealthEvent, this, _1, _2, _3, _4, _5, _6);
     m_sn.onSwitchShutdownRequest = std::bind(&SaiPlayer::onSwitchShutdownRequest, this, _1);
     m_sn.onSwitchStateChange = std::bind(&SaiPlayer::onSwitchStateChange, this, _1, _2);
     m_sn.onBfdSessionStateChange = std::bind(&SaiPlayer::onBfdSessionStateChange, this, _1, _2);
@@ -189,6 +190,19 @@ void SaiPlayer::onPortHostTxReady(
 void SaiPlayer::onQueuePfcDeadlock(
         _In_ uint32_t count,
         _In_ const sai_queue_deadlock_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+void SaiPlayer::onSwitchAsicSdkHealthEvent(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
 {
     SWSS_LOG_ENTER();
 

--- a/saiplayer/SaiPlayer.h
+++ b/saiplayer/SaiPlayer.h
@@ -229,6 +229,14 @@ namespace saiplayer
                     _In_ uint32_t count,
                     _In_ const sai_queue_deadlock_notification_data_t *data);
 
+            void onSwitchAsicSdkHealthEvent(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_switch_asic_sdk_health_severity_t severity,
+                    _In_ sai_timespec_t timestamp,
+                    _In_ sai_switch_asic_sdk_health_category_t category,
+                    _In_ sai_switch_health_data_t data,
+                    _In_ const sai_u8_list_t description);
+
             void onSwitchShutdownRequest(
                     _In_ sai_object_id_t switch_id)  __attribute__ ((noreturn));
 

--- a/syncd/NotificationHandler.cpp
+++ b/syncd/NotificationHandler.cpp
@@ -96,6 +96,10 @@ void NotificationHandler::updateNotificationsPointers(
                 attr.value.ptr = (void*)m_switchNotifications.on_switch_shutdown_request;
                 break;
 
+            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+                attr.value.ptr = (void*)m_switchNotifications.on_switch_asic_sdk_health_event;
+                break;
+
             case SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY:
                 attr.value.ptr = (void*)m_switchNotifications.on_fdb_event;
                 break;
@@ -203,6 +207,21 @@ void NotificationHandler::onSwitchShutdownRequest(
     auto s = sai_serialize_switch_shutdown_request(switch_id);
 
     enqueueNotification(SAI_SWITCH_NOTIFICATION_NAME_SWITCH_SHUTDOWN_REQUEST, s);
+}
+
+void  NotificationHandler::onSwitchAsicSdkHealthEvent(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_switch_asic_sdk_health_event(switch_id, severity, timestamp, category, data, description);
+
+    enqueueNotification(SAI_SWITCH_NOTIFICATION_NAME_SWITCH_ASIC_SDK_HEALTH_EVENT, s);
 }
 
 void NotificationHandler::onSwitchStateChange(

--- a/syncd/NotificationHandler.h
+++ b/syncd/NotificationHandler.h
@@ -58,6 +58,14 @@ namespace syncd
                     _In_ uint32_t count,
                     _In_ const sai_queue_deadlock_notification_data_t *data);
 
+            void onSwitchAsicSdkHealthEvent(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_switch_asic_sdk_health_severity_t severity,
+                    _In_ sai_timespec_t timestamp,
+                    _In_ sai_switch_asic_sdk_health_category_t category,
+                    _In_ sai_switch_health_data_t data,
+                    _In_ const sai_u8_list_t description);
+
             void onSwitchShutdownRequest(
                     _In_ sai_object_id_t switch_id);
 

--- a/syncd/NotificationProcessor.h
+++ b/syncd/NotificationProcessor.h
@@ -97,6 +97,14 @@ namespace syncd
                     _In_ sai_object_id_t port_id,
                     _In_ sai_port_host_tx_ready_status_t *host_tx_ready_status);
 
+            void process_on_switch_asic_sdk_health_event(
+                    _In_ sai_object_id_t switch_id,
+                    _In_ sai_switch_asic_sdk_health_severity_t severity,
+                    _In_ sai_timespec_t timestamp,
+                    _In_ sai_switch_asic_sdk_health_category_t category,
+                    _In_ sai_switch_health_data_t data,
+                    _In_ const sai_u8_list_t description);
+
             void process_on_switch_shutdown_request(
                     _In_ sai_object_id_t switch_rid);
 
@@ -122,6 +130,9 @@ namespace syncd
                     _In_ const std::string &data);
 
             void handle_bfd_session_state_change(
+                    _In_ const std::string &data);
+
+            void handle_switch_asic_sdk_health_event(
                     _In_ const std::string &data);
 
             void handle_switch_shutdown_request(

--- a/syncd/SwitchNotifications.cpp
+++ b/syncd/SwitchNotifications.cpp
@@ -97,6 +97,19 @@ void SwitchNotifications::SlotBase::onQueuePfcDeadlock(
 
     return m_slots[context]->m_handler->onQueuePfcDeadlock(count, data);
 }
+void SwitchNotifications::SlotBase::onSwitchAsicSdkHealthEvent(
+        _In_ int context,
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+
+    return m_slots.at(context)->m_handler->onSwitchAsicSdkHealthEvent(switch_id, severity, timestamp, category, data, description);
+}
 
 void SwitchNotifications::SlotBase::onSwitchShutdownRequest(
         _In_ int context,

--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -62,6 +62,15 @@ namespace syncd
                             _In_ uint32_t count,
                             _In_ const sai_queue_deadlock_notification_data_t *data);
 
+                    static void onSwitchAsicSdkHealthEvent(
+                            _In_ int context,
+                            _In_ sai_object_id_t switch_id,
+                            _In_ sai_switch_asic_sdk_health_severity_t severity,
+                            _In_ sai_timespec_t timestamp,
+                            _In_ sai_switch_asic_sdk_health_category_t category,
+                            _In_ sai_switch_health_data_t data,
+                            _In_ const sai_u8_list_t description);
+
                     static void onSwitchShutdownRequest(
                             _In_ int context,
                             _In_ sai_object_id_t switch_id);
@@ -106,7 +115,7 @@ namespace syncd
                             .on_tam_event = nullptr,
                             .on_ipsec_sa_status_change = nullptr,
                             .on_nat_event = &Slot<context>::onNatEvent,
-                            .on_switch_asic_sdk_health_event = nullptr,
+                            .on_switch_asic_sdk_health_event = &Slot<context>::onSwitchAsicSdkHealthEvent,
                             .on_port_host_tx_ready = &Slot<context>::onPortHostTxReady,
                             .on_twamp_session_event = &Slot<context>::onTwampSessionEvent,
                             }) { }
@@ -170,6 +179,25 @@ namespace syncd
                     return SlotBase::onQueuePfcDeadlock(context, count, data);
                 }
 
+                static void onSwitchAsicSdkHealthEvent(
+                        _In_ sai_object_id_t switch_id,
+                        _In_ sai_switch_asic_sdk_health_severity_t severity,
+                        _In_ sai_timespec_t timestamp,
+                        _In_ sai_switch_asic_sdk_health_category_t category,
+                        _In_ sai_switch_health_data_t data,
+                        _In_ const sai_u8_list_t description)
+                {
+                    SWSS_LOG_ENTER();
+
+                    return SlotBase::onSwitchAsicSdkHealthEvent(context,
+                                                                 switch_id,
+                                                                 severity,
+                                                                 timestamp,
+                                                                 category,
+                                                                 data,
+                                                                 description);
+                }
+
                 static void onSwitchShutdownRequest(
                         _In_ sai_object_id_t switch_id)
                 {
@@ -216,6 +244,12 @@ namespace syncd
             std::function<void(uint32_t, const sai_port_oper_status_notification_t*)>               onPortStateChange;
             std::function<void(sai_object_id_t, sai_object_id_t, sai_port_host_tx_ready_status_t)>  onPortHostTxReady;
             std::function<void(uint32_t, const sai_queue_deadlock_notification_data_t*)>            onQueuePfcDeadlock;
+            std::function<void(sai_object_id_t,
+                               sai_switch_asic_sdk_health_severity_t,
+                               sai_timespec_t,
+                               sai_switch_asic_sdk_health_category_t,
+                               sai_switch_health_data_t,
+                               const sai_u8_list_t)>                                                onSwitchAsicSdkHealthEvent;
             std::function<void(sai_object_id_t)>                                                    onSwitchShutdownRequest;
             std::function<void(sai_object_id_t switch_id, sai_switch_oper_status_t)>                onSwitchStateChange;
             std::function<void(uint32_t, const sai_bfd_session_state_notification_t*)>              onBfdSessionStateChange;

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -155,6 +155,7 @@ Syncd::Syncd(
     m_sn.onNatEvent = std::bind(&NotificationHandler::onNatEvent, m_handler.get(), _1, _2);
     m_sn.onPortStateChange = std::bind(&NotificationHandler::onPortStateChange, m_handler.get(), _1, _2);
     m_sn.onQueuePfcDeadlock = std::bind(&NotificationHandler::onQueuePfcDeadlock, m_handler.get(), _1, _2);
+    m_sn.onSwitchAsicSdkHealthEvent = std::bind(&NotificationHandler::onSwitchAsicSdkHealthEvent, m_handler.get(), _1, _2, _3, _4, _5, _6);
     m_sn.onSwitchShutdownRequest = std::bind(&NotificationHandler::onSwitchShutdownRequest, m_handler.get(), _1);
     m_sn.onSwitchStateChange = std::bind(&NotificationHandler::onSwitchStateChange, m_handler.get(), _1, _2);
     m_sn.onBfdSessionStateChange = std::bind(&NotificationHandler::onBfdSessionStateChange, m_handler.get(), _1, _2);

--- a/unittest/lib/TestSwitch.cpp
+++ b/unittest/lib/TestSwitch.cpp
@@ -22,7 +22,7 @@ TEST(Switch, updateNotifications)
 {
     auto s = std::make_shared<Switch>(7);
 
-    sai_attribute_t attrs[10];
+    sai_attribute_t attrs[11];
 
     attrs[0].id = 10000;
 
@@ -38,6 +38,7 @@ TEST(Switch, updateNotifications)
     attrs[7].value.ptr = (void*)1;
     attrs[8].value.ptr = (void*)1;
     attrs[9].value.ptr = (void*)1;
+    attrs[10].value.ptr = (void*)1;
 
     attrs[0].id = SAI_SWITCH_ATTR_SWITCH_STATE_CHANGE_NOTIFY;
     attrs[1].id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
@@ -48,7 +49,8 @@ TEST(Switch, updateNotifications)
     attrs[6].id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;
     attrs[7].id = SAI_SWITCH_ATTR_NAT_EVENT_NOTIFY;
     attrs[8].id = SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY;
-    attrs[9].id = SAI_SWITCH_ATTR_INIT_SWITCH;
+    attrs[9].id = SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY;
+    attrs[10].id = SAI_SWITCH_ATTR_INIT_SWITCH;
 
     s->updateNotifications(9, attrs);
 
@@ -63,4 +65,5 @@ TEST(Switch, updateNotifications)
     EXPECT_EQ((void*)1, sn.on_switch_state_change);
     EXPECT_EQ((void*)1, sn.on_nat_event);
     EXPECT_EQ((void*)1, sn.on_port_host_tx_ready);
+    EXPECT_EQ((void*)1, sn.on_switch_asic_sdk_health_event);
 }

--- a/unittest/meta/Makefile.am
+++ b/unittest/meta/Makefile.am
@@ -23,6 +23,7 @@ tests_SOURCES = \
 				TestNotificationPortStateChange.cpp \
 				TestNotificationQueuePfcDeadlock.cpp \
 				TestNotificationSwitchShutdownRequest.cpp \
+				TestNotificationSwitchAsicSdkHealthEvent.cpp \
 				TestNotificationSwitchStateChange.cpp \
 				TestNotificationBfdSessionStateChange.cpp \
 				TestOidRefCounter.cpp \

--- a/unittest/meta/TestNotificationFactory.cpp
+++ b/unittest/meta/TestNotificationFactory.cpp
@@ -68,6 +68,25 @@ TEST(NotificationFactory, deserialize_queue_pfc_deadlock)
     EXPECT_EQ(str, ntf->getSerializedNotification());
 }
 
+TEST(NotificationFactory, deserialize_switch_asic_sdk_health_event)
+{
+    auto ntf = NotificationFactory::deserialize(
+        SAI_SWITCH_NOTIFICATION_NAME_SWITCH_ASIC_SDK_HEALTH_EVENT,
+        "{"
+            "\"category\":\"SAI_SWITCH_ASIC_SDK_HEALTH_CATEGORY_FW\","
+            "\"data.data_type\":\"SAI_HEALTH_DATA_TYPE_GENERAL\","
+            "\"description\":\"2:30,30\","
+            "\"severity\":\"SAI_SWITCH_ASIC_SDK_HEALTH_SEVERITY_FATAL\","
+            "\"switch_id\":\"oid:0x21000000000000\","
+            "\"timestamp\":\"{"
+                "\\\"tv_nsec\\\":\\\"28715881\\\","
+                "\\\"tv_sec\\\":\\\"1700042919\\\""
+            "}\""
+        "}");
+
+    EXPECT_EQ(ntf->getNotificationType(), SAI_SWITCH_NOTIFICATION_TYPE_SWITCH_ASIC_SDK_HEALTH_EVENT);
+}
+
 TEST(NotificationFactory, deserialize_shutdown_request)
 {
     auto ntf = NotificationFactory::deserialize(

--- a/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
+++ b/unittest/meta/TestNotificationSwitchAsicSdkHealthEvent.cpp
@@ -1,0 +1,78 @@
+#include "NotificationSwitchAsicSdkHealthEvent.h"
+#include "Meta.h"
+#include "MetaTestSaiInterface.h"
+
+#include "sairediscommon.h"
+#include "sai_serialize.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+
+using namespace sairedis;
+using namespace saimeta;
+
+//static std::string s = "[{\"host_tx_ready_status\":\"SAI_PORT_HOST_TX_READY_STATUS_READY\",\"port_id\":\"oid:0x100000000001a\",\"switch_id\":\"oid:0x2100000000\"}]";
+static std::string s = "{"
+                           "\"category\":\"SAI_SWITCH_ASIC_SDK_HEALTH_CATEGORY_FW\","
+                           "\"data.data_type\":\"SAI_HEALTH_DATA_TYPE_GENERAL\","
+                           "\"description\":\"2:30,30\","
+                           "\"severity\":\"SAI_SWITCH_ASIC_SDK_HEALTH_SEVERITY_FATAL\","
+                           "\"switch_id\":\"oid:0x21000000000000\","
+                           "\"timestamp\":\"{"
+                                   "\\\"tv_nsec\\\":\\\"28715881\\\","
+                                   "\\\"tv_sec\\\":\\\"1700042919\\\""
+                           "}\""
+                       "}";
+static std::string null = "[{\"host_tx_ready_status\":\"SAI_PORT_HOST_TX_READY_STATUS_READY\",\"port_id\":\"oid:0x0\",\"switch_id\":\"oid:0x0\"}]";
+static std::string fullnull = "[]";
+
+TEST(NotificationSwitchAsicSdkHealthEvent, ctr)
+{
+    NotificationSwitchAsicSdkHealthEvent n(s);
+}
+
+TEST(NotificationSwitchAsicSdkHealthEvent, getSwitchId)
+{
+    NotificationSwitchAsicSdkHealthEvent n(s);
+
+    EXPECT_EQ(n.getSwitchId(), 0x21000000000000);
+}
+
+TEST(NotificationSwitchAsicSdkHealthEvent, getAnyObjectId)
+{
+    NotificationSwitchAsicSdkHealthEvent n(s);
+
+    EXPECT_EQ(n.getAnyObjectId(), 0x21000000000000);
+}
+
+TEST(NotificationSwitchAsicSdkHealthEvent, processMetadata)
+{
+    NotificationSwitchAsicSdkHealthEvent n(s);
+
+    auto sai = std::make_shared<MetaTestSaiInterface>();
+    auto meta = std::make_shared<Meta>(sai);
+
+    n.processMetadata(meta);
+}
+
+static void on_switch_asic_sdk_health_event(
+        _In_ sai_object_id_t switch_id,
+        _In_ sai_switch_asic_sdk_health_severity_t severity,
+        _In_ sai_timespec_t timestamp,
+        _In_ sai_switch_asic_sdk_health_category_t category,
+        _In_ sai_switch_health_data_t data,
+        _In_ const sai_u8_list_t description)
+{
+    SWSS_LOG_ENTER();
+}
+
+TEST(NotificationSwitchAsicSdkHealthEvent, executeCallback)
+{
+    NotificationSwitchAsicSdkHealthEvent n(s);
+
+    sai_switch_notifications_t ntfs;
+
+    ntfs.on_switch_asic_sdk_health_event = &on_switch_asic_sdk_health_event;
+
+    n.executeCallback(ntfs);
+}

--- a/vslib/Switch.cpp
+++ b/vslib/Switch.cpp
@@ -80,6 +80,11 @@ void Switch::updateNotifications(
                     (sai_switch_state_change_notification_fn)attr.value.ptr;
                 break;
 
+            case SAI_SWITCH_ATTR_SWITCH_ASIC_SDK_HEALTH_EVENT_NOTIFY:
+                m_switchNotifications.on_switch_asic_sdk_health_event =
+                    (sai_switch_asic_sdk_health_event_notification_fn)attr.value.ptr;
+                break;
+
             case SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY:
                 m_switchNotifications.on_switch_shutdown_request =
                     (sai_switch_shutdown_request_notification_fn)attr.value.ptr;


### PR DESCRIPTION
Support ASIC/SDK health event
1. Handle vendor SAI ASIC/SDK health event and encode it
2. Pass it to swss through the communication channel.