### PR TITLE
Revert "Do not enter vendor SAI critical section for counter polling/clearing operations (#1450)"

### DIFF
--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -313,6 +313,7 @@ sai_status_t VendorSai::getStats(
         _In_ const sai_stat_id_t *counter_ids,
         _Out_ uint64_t *counters)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -350,6 +351,7 @@ sai_status_t VendorSai::getStatsExt(
         _In_ sai_stats_mode_t mode,
         _Out_ uint64_t *counters)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -364,6 +366,7 @@ sai_status_t VendorSai::clearStats(
         _In_ uint32_t number_of_counters,
         _In_ const sai_stat_id_t *counter_ids)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -383,6 +386,7 @@ sai_status_t VendorSai::bulkGetStats(
         _Inout_ sai_status_t *object_statuses,
         _Out_ uint64_t *counters)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
@@ -410,6 +414,7 @@ sai_status_t VendorSai::bulkClearStats(
         _In_ sai_stats_mode_t mode,
         _Inout_ sai_status_t *object_statuses)
 {
+    MUTEX();
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 


### PR DESCRIPTION
Revert "Do not enter vendor SAI critical section for counter polling/clearing operations (#1450)"

This reverts commit 0317b16e4fdccf769c77a7b164ff90c1365c7d4e.