### PR TITLE
Move time stamp to time stamp table in counter database to avoid frequently update the counter table

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1303,10 +1303,17 @@ private:
             {
                 values.emplace_back(serializeStat(ctx.counter_ids[j]), std::to_string(ctx.counters[i * ctx.counter_ids.size() + j]));
             }
-            values.emplace_back(m_instanceId + "_time_stamp", std::to_string(time_stamp));
+
             countersTable.set(sai_serialize_object_id(vid), values, "");
             values.clear();
         }
+
+        // First generate the key, then replace spaces with underscores to avoid issues when Lua plugins handle the timestamp
+        std::string timestamp_key = "PFC_WD_" + m_name + "_time_stamp";
+        std::replace(timestamp_key.begin(), timestamp_key.end(), ' ', '_');
+
+        values.emplace_back(timestamp_key, std::to_string(time_stamp));
+        countersTable.set("TIME_STAMP", values, "");
 
         SWSS_LOG_DEBUG("After pushing db %s %s %s", m_instanceId.c_str(), m_name.c_str(), ctx.name.c_str());
     }


### PR DESCRIPTION
Move the timestamp out of the COUNTER table to avoid updating the table too frequently and overwhelming the telemetry system.